### PR TITLE
fix(walks): consume cuGraph edge_attrs return + stride-aligned reshape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.1] — 2026-04-27
+
+### Fixed
+
+- **Walk corpus: predicates now match the edge cuGraph actually traversed.**
+  Both `SingleGPUWalkCorpus.random_walk` and `MultiGPUWalkCorpus.random_walk`
+  used to discard the `edge_attrs` return from `cugraph.uniform_random_walks`
+  / `biased_random_walks` and re-derive the per-step predicate via a
+  `(src, dst)` merge against the edge table. On `cugraph.MultiGraph`
+  instances with parallel edges (multiple predicates between the same
+  vertex pair) the merge was non-unique on the right side — cuDF picked an
+  arbitrary matching predicate per row, so walks could end up annotated
+  with a predicate the walker never traversed. Now the `edge_attrs` return
+  is consumed directly via the new `_build_walk_steps` reshape helper.
+- **Multi-GPU walks: no more silent row loss at dask-partition boundaries.**
+  The previous `_build_walk_df` closure ran inside `map_partitions` and did
+  `df["dst"] = df["src"].shift(-1); df = df.iloc[:-1]`, dropping the last
+  row of every dask partition rather than the last row of every walk.
+  Because partitions don't respect walk boundaries, a walk that started in
+  partition N and ended in partition N+1 lost its final step or terminal
+  vertex. The new reshape works on stride-aligned (vertex, edge_attr)
+  pairs directly, so no partition-boundary trim is needed.
+- **Multi-GPU walks: walk_ids are now globally unique across partitions.**
+  The previous `cp.arange(len(df)) // max_len` ran per-partition and
+  produced walk_ids `0..n_walks_in_partition`, which collided across
+  partitions. The downstream skip-gram pair builder does a dask merge on
+  `(walk_id, pos)`, so collisions silently created spurious cross-walk
+  pairs. The reshape helper now takes a `walk_id_offset`, and the multi-GPU
+  caller computes per-partition cumulative-walk offsets so ids are globally
+  unique.
+
+### Performance
+
+- **Multi-GPU walks: removed a multi-billion-row merge.** The
+  `walks.merge(edge_ddf, ...)` predicate-recovery step is gone. On
+  Wikidata-scale graphs (1.38 B edges, 390 M vertices, walks_per_vertex=10,
+  walk_length=8) the merge was the pipeline's worst-scaling stage after
+  vocab generation. The reshape pattern is O(n_walks).
+
+### Added
+
+- `_build_walk_steps(vertices_s, edge_attrs_s, walk_length, walk_id_offset)`
+  in `rdf2vecgpu.corpus.walk_corpus` — a per-partition reshape helper that
+  consumes cuGraph's flat `(vertices, edge_attrs)` walk output and emits
+  the `[src, predicate, dst, walk_id, step]` schema downstream code already
+  consumes. Drops cuGraph's `-1` sentinel rows for early-terminating walks.
+- `test/corpus/walk_corpus_test.py` — regression tests for the reshape
+  helper layout, walk_id offsetting, sentinel handling, stride validation,
+  and an integration smoke that asserts emitted predicates exist between
+  the (src, dst) pair the walker actually stepped on.
+- `gpu` pytest marker registered in `pyproject.toml`'s
+  `[tool.pytest.ini_options]`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rdf2vecgpu"
-version = "0.3.0"
+version = "0.3.1"
 description = "GPU-Accelerated RDF2Vec – A high-performance GPU implementation of RDF2Vec that uses CUDA and RAPIDS to generate scalable, embeddings for large dense knowledge graphs."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -48,3 +48,6 @@ test = [
 [tool.pytest.ini_options]
 testpaths = ["test"]
 pythonpath = ["."]
+markers = [
+    "gpu: tests that require a CUDA-capable GPU (run with `pytest --gpu`)",
+]

--- a/src/rdf2vecgpu/corpus/walk_corpus.py
+++ b/src/rdf2vecgpu/corpus/walk_corpus.py
@@ -1,5 +1,6 @@
 import cupy as cp
 import cudf
+import dask
 import dask_cudf as dcudf
 from loguru import logger
 from cugraph import uniform_random_walks, biased_random_walks, filter_unreachable, bfs
@@ -12,6 +13,64 @@ import torch
 # ── Shared corpus-building helpers ──────────────────────────────────────────
 # These work on both cudf and dask_cudf DataFrames because the API surface
 # (concat, sort_values, merge, groupby, rename, assign) is identical.
+
+
+def _build_walk_steps(vertices_s, edge_attrs_s, walk_length, walk_id_offset=0):
+    """Reshape cuGraph's flat random-walk output into per-step rows.
+
+    cuGraph's `uniform_random_walks` / `biased_random_walks` emit two parallel
+    series:
+      vertices_s:   length n_walks * (walk_length + 1)  — vertex sequence per walk
+      edge_attrs_s: length n_walks *  walk_length       — predicate per step
+
+    Both are stride-aligned: each partition holds an integer multiple of the
+    stride. We reshape directly to `(n_walks, stride)` and emit the schema
+    downstream `_triples_to_tokens` already consumes:
+        [src, predicate, dst, walk_id, step]
+
+    `walk_id_offset` lets callers assign globally-unique walk_ids when this
+    helper is invoked per-partition under dask: pass the cumulative walk count
+    of all preceding partitions so walk_ids don't collide.
+
+    Walks shorter than `walk_length` are padded with cuGraph's `-1` sentinel;
+    we drop steps where any of (src, predicate, dst) is -1.
+    """
+    stride_v = walk_length + 1
+    stride_p = walk_length
+    n_walks = len(vertices_s) // stride_v
+    if n_walks * stride_v != len(vertices_s):
+        raise ValueError(
+            f"vertex partition size {len(vertices_s)} is not a multiple of "
+            f"walk stride {stride_v}; cuGraph's walk output is expected to be "
+            f"stride-aligned"
+        )
+    if len(edge_attrs_s) != n_walks * stride_p:
+        raise ValueError(
+            f"edge_attrs partition size {len(edge_attrs_s)} does not match "
+            f"expected {n_walks * stride_p} (n_walks={n_walks}, "
+            f"walk_length={walk_length})"
+        )
+    vs = cp.asarray(vertices_s.values).reshape(n_walks, stride_v)
+    ps = cp.asarray(edge_attrs_s.values).reshape(n_walks, stride_p)
+    src = vs[:, :-1].reshape(-1)
+    dst = vs[:, 1:].reshape(-1)
+    predicate = ps.reshape(-1)
+    walk_id = cp.repeat(
+        cp.arange(n_walks, dtype="int64") + int(walk_id_offset), stride_p
+    )
+    step = cp.tile(cp.arange(stride_p, dtype="int64"), n_walks)
+    df = cudf.DataFrame(
+        {
+            "src": src,
+            "predicate": predicate,
+            "dst": dst,
+            "walk_id": walk_id,
+            "step": step,
+        }
+    )
+    # Drop padded steps (cuGraph sentinels).
+    mask = (df["src"] != -1) & (df["dst"] != -1) & (df["predicate"] != -1)
+    return df[mask].reset_index(drop=True)
 
 
 def _triples_to_tokens_partition(df):
@@ -221,27 +280,24 @@ class SingleGPUWalkCorpus:
         min_count: int,
     ) -> cudf.DataFrame:
         walk_fn = biased_random_walks if self.walk_weighted else uniform_random_walks
-        random_walks, _, max_length = walk_fn(
+        # Capture all three returns: (vertex_paths, edge_attrs, max_length).
+        # When the graph was built with `edge_attr="predicate"`, edge_attrs is
+        # the per-step predicate cuGraph actually used — no need to merge it
+        # back from `edge_df`. The previous merge-based recovery picked an
+        # arbitrary predicate per (src, dst) pair on `MultiGraph` (silent
+        # correctness bug for graphs with parallel edges).
+        random_walks, edge_attrs, max_length = walk_fn(
             self.G,
             start_vertices=walk_vertices,
             max_depth=walk_depth,
             random_state=random_state,
         )
-        group_keys = cudf.Series(cp.arange(len(random_walks))) // max_length
-        transformed_random_walk = random_walks.to_frame(name="src")
-        transformed_random_walk["walk_id"] = group_keys
-        transformed_random_walk["dst"] = transformed_random_walk["src"].shift(-1)
-        transformed_random_walk = transformed_random_walk.mask(
-            transformed_random_walk == -1, [None, None, None]
-        ).dropna()
-
-        transformed_random_walk["step"] = transformed_random_walk.groupby(
-            "walk_id"
-        ).cumcount()
-        merged_walks = transformed_random_walk.merge(
-            edge_df, left_on=["src", "dst"], right_on=["subject", "object"], how="left"
-        )[["src", "predicate", "dst", "walk_id", "step"]]
-        merged_walks = merged_walks.dropna()
+        merged_walks = _build_walk_steps(
+            random_walks, edge_attrs, walk_length=int(max_length)
+        )
+        # `_build_walk_steps` already drops the cuGraph -1 sentinel rows and
+        # emits stride-aligned (walk_id, step) — preserve the legacy explicit
+        # sort so downstream behavior is unchanged.
         merged_walks = merged_walks.sort_values(["walk_id", "step"])
         tokens = _triples_to_tokens(merged_walks, min_count, concat_fn=cudf.concat)
         return _dispatch_pairs(tokens, self.window_size, word2vec_model, concat_fn=cudf.concat)
@@ -300,38 +356,67 @@ class MultiGPUWalkCorpus:
         walk_fn = dask_biased_random_walks if self.walk_weighted else dask_uniform_random_walks
         walk_label = "biased" if self.walk_weighted else "uniform"
         logger.info(f"Running multi-GPU {walk_label}_random_walks …")
-        # cuGraph requires unique seeds per GPU — omit to let it auto-seed
-        walks_s, _, max_len = walk_fn(
+        # cuGraph requires unique seeds per GPU — omit to let it auto-seed.
+        # Capture all three returns: (vertex_paths, edge_attrs, max_length).
+        # edge_attrs carries the per-step predicate cuGraph actually used
+        # (when the graph was built with edge_attr="predicate"). Using it
+        # directly avoids the multi-billion-row merge against `edge_ddf` that
+        # the previous implementation did, and removes a silent correctness
+        # bug on `MultiGraph` (the merge picked an arbitrary predicate per
+        # parallel edge).
+        from dask.distributed import wait as dask_wait
+
+        walks_s, edge_attrs_s, max_len = walk_fn(
             self.G,
             start_vertices=start_vertices,
             max_depth=walk_depth,
         )
+        walk_length = int(max_len)
 
-        def _build_walk_df(s, max_len):
-            """Build walk DataFrame with walk_id, dst, step from vertex Series."""
-            df = s.to_frame(name="src").reset_index(drop=True)
-            df["global_pos"] = cp.arange(len(df))
-            df["walk_id"] = df["global_pos"].astype("int64") // max_len
-            df["dst"] = df["src"].shift(-1)
-            # Drop last row of each partition (incomplete src→dst pair)
-            df = df.iloc[:-1]
-            df["step"] = df.groupby("walk_id").cumcount()
-            return df
+        # Persist + wait BEFORE the reshape so the walk generator doesn't
+        # re-roll on the per-partition size pass below (uniform_random_walks
+        # is stochastic; without persist, every consumer triggers a fresh
+        # roll).
+        walks_s = walks_s.persist()
+        edge_attrs_s = edge_attrs_s.persist()
+        dask_wait([walks_s, edge_attrs_s])
 
-        walks = walks_s.map_partitions(_build_walk_df, max_len)
+        # Compute per-partition walk counts so we can assign globally-unique
+        # walk_ids. The previous per-partition `cp.arange(len(df)) // max_len`
+        # produced partition-local ids that collided across partitions, which
+        # poisoned the downstream skip-gram merge on (walk_id, pos).
+        stride_v = walk_length + 1
+        vertex_part_sizes = walks_s.map_partitions(len).compute()
+        walks_per_part = [int(s) // stride_v for s in vertex_part_sizes]
+        offsets = [0]
+        for c in walks_per_part[:-1]:
+            offsets.append(offsets[-1] + c)
 
-        merged = walks.merge(
-            edge_ddf,
-            left_on=["src", "dst"],
-            right_on=["subject", "object"],
-            how="left",
-        ).dropna(subset=["predicate"])
-        merged = merged[["src", "predicate", "dst", "walk_id", "step"]]
+        # Combine the two aligned series partition-wise via from_delayed so
+        # each partition gets its own walk_id offset. The reshape replaces
+        # the previous `shift(-1) + iloc[:-1]` pattern, which silently dropped
+        # the row at every partition boundary.
+        walks_delayed = walks_s.to_delayed()
+        edges_delayed = edge_attrs_s.to_delayed()
+        meta = cudf.DataFrame(
+            {
+                "src": cudf.Series([], dtype=walks_s.dtype),
+                "predicate": cudf.Series([], dtype=edge_attrs_s.dtype),
+                "dst": cudf.Series([], dtype=walks_s.dtype),
+                "walk_id": cudf.Series([], dtype="int64"),
+                "step": cudf.Series([], dtype="int64"),
+            }
+        )
+        merged_parts = [
+            dask.delayed(_build_walk_steps)(
+                walks_delayed[i], edges_delayed[i], walk_length, offsets[i]
+            )
+            for i in range(len(walks_delayed))
+        ]
+        merged = dcudf.from_delayed(merged_parts, meta=meta)
 
-        # Materialize the merged walks across Dask workers.  This collapses
-        # the dask-expr lazy graph (walks + edge merge) into concrete
-        # partitions before the token/pair extraction builds further on top.
-        from dask.distributed import wait as dask_wait
+        # Materialize the reshape across workers before the token/pair stage
+        # consumes it (preserves the original persist+wait idiom).
         merged = merged.persist()
         dask_wait(merged)
 

--- a/test/corpus/walk_corpus_test.py
+++ b/test/corpus/walk_corpus_test.py
@@ -1,0 +1,167 @@
+"""Tests for the random-walk corpus path.
+
+Covers the correctness fixes made when we stopped re-deriving predicates via
+a (src, dst) merge and started consuming cuGraph's `edge_attrs` return value
+directly. The merge-based recovery had two silent bugs on Wikidata-scale
+graphs:
+  1. On `cugraph.MultiGraph` with parallel edges, the (src, dst) merge is
+     non-unique on the right side — cuDF picks an arbitrary matching
+     predicate per row, so walks could end up with predicates the walker
+     never traversed.
+  2. The multi-GPU path's `_build_walk_df` did `shift(-1) + iloc[:-1]` per
+     dask partition, which dropped the last row of every partition — a
+     walk-boundary tail vertex when partition cuts crossed a walk.
+  3. As a corollary of the multi-GPU partition-local `cp.arange(len(df))`
+     walk-id assignment, walk_ids collided across partitions, poisoning the
+     downstream skip-gram (walk_id, pos) merge.
+
+The new `_build_walk_steps` reshape helper sidesteps all three; these tests
+exercise its mechanics and the calling-side smoke against a single-GPU
+`MultiGraph`.
+"""
+from __future__ import annotations
+
+import cupy as cp
+import cudf
+import pytest
+
+from src.rdf2vecgpu.corpus.walk_corpus import (
+    SingleGPUWalkCorpus,
+    _build_walk_steps,
+)
+
+
+@pytest.mark.gpu
+def test_build_walk_steps_basic_layout():
+    """Two walks of length 3 → 6 step rows; src, predicate, dst align."""
+    # walk 0: vertices [10, 11, 12, 13], predicates [100, 101, 102]
+    # walk 1: vertices [20, 21, 22, 23], predicates [200, 201, 202]
+    vertices = cudf.Series(
+        cp.array([10, 11, 12, 13, 20, 21, 22, 23], dtype="int32")
+    )
+    edge_attrs = cudf.Series(
+        cp.array([100, 101, 102, 200, 201, 202], dtype="int32")
+    )
+    out = _build_walk_steps(vertices, edge_attrs, walk_length=3)
+    assert list(out.columns) == ["src", "predicate", "dst", "walk_id", "step"]
+    assert len(out) == 6
+    out_sorted = out.sort_values(["walk_id", "step"]).reset_index(drop=True)
+    # Walk 0
+    assert out_sorted["src"].iloc[0] == 10 and out_sorted["dst"].iloc[0] == 11
+    assert out_sorted["predicate"].iloc[0] == 100
+    assert out_sorted["src"].iloc[2] == 12 and out_sorted["dst"].iloc[2] == 13
+    assert out_sorted["predicate"].iloc[2] == 102
+    # Walk 1
+    assert out_sorted["src"].iloc[3] == 20 and out_sorted["dst"].iloc[3] == 21
+    assert out_sorted["predicate"].iloc[3] == 200
+    assert out_sorted["walk_id"].to_pandas().tolist() == [0, 0, 0, 1, 1, 1]
+    assert out_sorted["step"].to_pandas().tolist() == [0, 1, 2, 0, 1, 2]
+
+
+@pytest.mark.gpu
+def test_build_walk_steps_offset_yields_global_walk_ids():
+    """`walk_id_offset` shifts the per-partition walk_ids globally.
+
+    This is the exact mechanism the multi-GPU path relies on to avoid the
+    partition-local walk_id collision that poisoned the previous code.
+    """
+    vertices = cudf.Series(cp.array([10, 11, 20, 21], dtype="int32"))
+    edge_attrs = cudf.Series(cp.array([100, 200], dtype="int32"))
+    out = _build_walk_steps(vertices, edge_attrs, walk_length=1, walk_id_offset=42)
+    assert sorted(out["walk_id"].to_pandas().tolist()) == [42, 43]
+
+
+@pytest.mark.gpu
+def test_build_walk_steps_drops_padded_steps():
+    """cuGraph's -1 sentinel marks early-terminating walks; those rows drop."""
+    # walk 0: full length 3
+    # walk 1: length 1 then padded with -1
+    vertices = cudf.Series(
+        cp.array([10, 11, 12, 13, 20, 21, -1, -1], dtype="int32")
+    )
+    edge_attrs = cudf.Series(
+        cp.array([100, 101, 102, 200, -1, -1], dtype="int32")
+    )
+    out = _build_walk_steps(vertices, edge_attrs, walk_length=3)
+    # 3 rows from walk 0 + 1 valid row from walk 1 = 4
+    assert len(out) == 4
+    assert (out["src"] != -1).all()
+    assert (out["dst"] != -1).all()
+    assert (out["predicate"] != -1).all()
+
+
+@pytest.mark.gpu
+def test_build_walk_steps_rejects_misaligned_input():
+    """Stride-misaligned input fails loudly rather than silently truncating."""
+    bad_vertices = cudf.Series(cp.array([1, 2, 3, 4, 5], dtype="int32"))  # not %4
+    edge_attrs = cudf.Series(cp.array([10, 11, 12], dtype="int32"))
+    with pytest.raises(ValueError, match="not a multiple of walk stride"):
+        _build_walk_steps(bad_vertices, edge_attrs, walk_length=3)
+
+
+@pytest.mark.gpu
+def test_random_walk_predicate_matches_traversed_edge():
+    """Walks over a `MultiGraph` with parallel edges emit predicates that
+    actually exist between the (src, dst) pair the walker stepped on.
+
+    Pre-fix, the merge-based predicate recovery would pick *any* of the
+    parallel predicates per (src, dst) lookup; post-fix, the predicate is
+    exactly the one cuGraph chose. The weaker invariant "predicate ∈
+    edges_between(src, dst)" still holds in both — but if a future
+    regression swaps in a different attribute (e.g. edge weight) the test
+    will fail because the value won't be in the legitimate predicate set.
+    """
+    from cugraph import MultiGraph, uniform_random_walks
+
+    # Parallel edges: (0,1) has predicates 100 and 101.
+    edge_df = cudf.DataFrame(
+        {
+            "subject": cudf.Series([0, 0, 1, 2], dtype="int32"),
+            "predicate": cudf.Series([100, 101, 200, 300], dtype="int32"),
+            "object": cudf.Series([1, 1, 2, 0], dtype="int32"),
+        }
+    )
+    graph = MultiGraph(directed=True)
+    graph.from_cudf_edgelist(
+        edge_df,
+        source="subject",
+        destination="object",
+        edge_attr="predicate",
+        renumber=False,
+    )
+
+    start = cudf.Series([0, 0, 0, 0], dtype="int32")
+    vp, ea, max_len = uniform_random_walks(
+        graph, start_vertices=start, max_depth=2, random_state=0
+    )
+    steps = _build_walk_steps(vp, ea, walk_length=int(max_len))
+
+    # Legitimate (src, dst) → {predicates} map from the edge list.
+    edge_pd = edge_df.to_pandas()
+    legit: dict[tuple[int, int], set[int]] = {}
+    for _, row in edge_pd.iterrows():
+        legit.setdefault((int(row["subject"]), int(row["object"])), set()).add(
+            int(row["predicate"])
+        )
+
+    steps_pd = steps.to_pandas()
+    for _, row in steps_pd.iterrows():
+        key = (int(row["src"]), int(row["dst"]))
+        assert key in legit, f"walk traversed edge {key} that does not exist"
+        assert int(row["predicate"]) in legit[key], (
+            f"walk emitted predicate {int(row['predicate'])} for edge {key}; "
+            f"only {legit[key]} are legitimate predicates between them"
+        )
+
+    # Smoke the public single-GPU corpus API end-to-end.
+    corpus = SingleGPUWalkCorpus(graph, window_size=2, walk_weighted=False)
+    pairs = corpus.random_walk(
+        edge_df=edge_df,
+        walk_vertices=start,
+        walk_depth=2,
+        random_state=0,
+        word2vec_model="skipgram",
+        min_count=1,
+    )
+    assert isinstance(pairs, cudf.DataFrame)
+    assert {"center", "context"}.issubset(set(pairs.columns))


### PR DESCRIPTION
Both `SingleGPUWalkCorpus.random_walk` and `MultiGPUWalkCorpus.random_walk` discarded the second return value (`edge_attrs`) of `uniform_random_walks` / `biased_random_walks` and re-derived the per-step predicate via a `(src, dst)` merge against the edge table. On `cugraph.MultiGraph` with parallel edges (multiple predicates between the same vertex pair) the merge was non-unique on the right side, so cuDF picked an arbitrary matching predicate per row — walks could end up annotated with a predicate the walker never traversed. Silent correctness bug.

Two more silent bugs were piled in the multi-GPU `_build_walk_df`:

* `df["dst"] = df["src"].shift(-1); df = df.iloc[:-1]` ran inside `map_partitions`, so it dropped the last row of every dask partition rather than the last row of every walk. Walks that crossed a partition boundary lost their final step or terminal vertex.
* `df["walk_id"] = cp.arange(len(df)) // max_len` produced walk_ids `0..n_walks_in_partition` per partition — collisions across partitions poisoned the downstream skip-gram (walk_id, pos) merge with spurious cross-walk pairs.

This commit replaces all of the above with a new `_build_walk_steps` helper that consumes cuGraph's flat (vertices, edge_attrs) output via a stride-aligned reshape and emits the same `[src, predicate, dst, walk_id, step]` schema downstream code already consumes. The multi-GPU caller persists+waits the walk output, computes per-partition walk-count offsets, and feeds the helper via `dd.from_delayed` so walk_ids are globally unique.

As a side benefit, the multi-billion-row predicate-recovery merge is gone — on Wikidata-scale graphs (1.38 B edges) it was the worst-scaling stage after vocab generation. The reshape is O(n_walks).

Tests: 5 new cases in `test/corpus/walk_corpus_test.py` cover the helper's layout, walk_id offsetting, sentinel handling, stride validation, and an end-to-end smoke that asserts emitted predicates match an actual edge between the (src, dst) pair the walker stepped on. All 5 pass on GPU (1× RTX 2080 Ti, 89s).

Bumps version to 0.3.1; introduces CHANGELOG.md.