### PR TITLE
Feat/vocab hash partition and broadcast merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,61 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.1] — 2026-04-27
+## [Unreleased]
+
+### Added
+
+- `_build_walk_steps(vertices_s, edge_attrs_s, walk_length, walk_id_offset)`
+  in `rdf2vecgpu.corpus.walk_corpus` — a per-partition reshape helper that
+  consumes cuGraph's flat `(vertices, edge_attrs)` walk output and emits
+  the `[src, predicate, dst, walk_id, step]` schema downstream code already
+  consumes. Drops cuGraph's `-1` sentinel rows for early-terminating walks.
+- `_assign_ids(partition, offset)` private helper in
+  `rdf2vecgpu.helper.functions` — per-partition `cupy.arange + offset` used
+  by the new multi-GPU vocab builder.
+- `test/corpus/walk_corpus_test.py` — regression tests for the reshape
+  helper layout, walk_id offsetting, sentinel handling, stride validation,
+  and an integration smoke that asserts emitted predicates exist between
+  the (src, dst) pair the walker actually stepped on.
+- `test/helper/functions_test.py` —
+  `test_generate_vocab_multi_gpu_unique_tokens_contiguous_range` (catches
+  off-by-one in cumsum offsets) and
+  `test_generate_vocab_multi_gpu_round_trip_decodes_to_original_strings`
+  (catches row drift from broadcast merges or unstable shuffles).
+- `gpu` pytest marker registered in `pyproject.toml`'s
+  `[tool.pytest.ini_options]`.
+
+### Changed
+
+- **Multi-GPU vocab build: hash-partition rewrite (replaces categorize
+  funnel).** The previous `dd.concat(s, p, o).unique()` followed by
+  `vocabulary_df.categorize(columns=["word"])` funneled the full
+  deduplicated vocabulary onto a single worker for `sort_values()`. On
+  Wikidata-scale graphs (~390 M unique tokens) the single-worker sort
+  exceeded 40 GB of intermediate state and either OOM'd the GPU or hung
+  the worker. The replacement is embarrassingly parallel:
+  `shuffle(on="word", shuffle_method="tasks") → drop_duplicates() →
+  persist+wait → cumsum offsets → dask.delayed _assign_ids` per partition
+  with `cupy.arange + offset`. Token ids remain globally unique and form a
+  contiguous `[0, n)` range without any cross-partition shuffle. Result on
+  2× RTX A6000: ~13 min for the 390 M-token Wikidata vocab vs.
+  never-completes with the previous code path.
+- **Multi-GPU vocab build: persist+wait stabilizes the shuffle output.**
+  Without persist, the hash-shuffle re-rolls every time `sizes.compute()`
+  or the per-partition id assignment reads from it, and partition
+  assignments drift between rolls (the standalone tool that pioneered this
+  pattern observed 23 M → 15 M row loss between sizes.compute and the
+  eventual write). Persist + `dask.distributed.wait()` pins the shuffle
+  output before downstream consumers read it.
+- **Encode-side merges now use `broadcast=True`.** The three `.merge()`
+  calls that join `word2idx` into the edge table didn't specify
+  `broadcast=True`, so dask defaulted them to hash-shuffle joins. With a
+  small word2idx partition count, the 1.38 B-row edge side got funneled
+  through one worker — observed 6+ hours at 100 % single-GPU utilization
+  with no progress on Wikidata-scale runs. `broadcast=True` replicates the
+  small word2idx to every worker so each edge partition does a local hash
+  join with no shuffle of the large side; one hash-table build per worker
+  per merge instead of one per partition.
 
 ### Fixed
 
@@ -43,17 +97,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Wikidata-scale graphs (1.38 B edges, 390 M vertices, walks_per_vertex=10,
   walk_length=8) the merge was the pipeline's worst-scaling stage after
   vocab generation. The reshape pattern is O(n_walks).
-
-### Added
-
-- `_build_walk_steps(vertices_s, edge_attrs_s, walk_length, walk_id_offset)`
-  in `rdf2vecgpu.corpus.walk_corpus` — a per-partition reshape helper that
-  consumes cuGraph's flat `(vertices, edge_attrs)` walk output and emits
-  the `[src, predicate, dst, walk_id, step]` schema downstream code already
-  consumes. Drops cuGraph's `-1` sentinel rows for early-terminating walks.
-- `test/corpus/walk_corpus_test.py` — regression tests for the reshape
-  helper layout, walk_id offsetting, sentinel handling, stride validation,
-  and an integration smoke that asserts emitted predicates exist between
-  the (src, dst) pair the walker actually stepped on.
-- `gpu` pytest marker registered in `pyproject.toml`'s
-  `[tool.pytest.ini_options]`.

--- a/src/rdf2vecgpu/helper/functions.py
+++ b/src/rdf2vecgpu/helper/functions.py
@@ -1,7 +1,27 @@
 import cudf
+import cupy
+import dask
 import dask.dataframe as dd
+import dask_cudf
 import torch
 from torch.utils.dlpack import to_dlpack
+
+
+def _assign_ids(partition, offset):
+    """Per-partition int32 token assignment via `cupy.arange + offset`.
+
+    Used as the per-partition body of the multi-GPU vocab build. Each partition
+    of the deduplicated vocab gets a contiguous block of integer ids starting
+    at `offset` (computed from the cumulative sum of preceding partition
+    sizes), so token ids are globally unique and form a contiguous `[0, n)`
+    range without any cross-partition shuffle.
+    """
+    return cudf.DataFrame(
+        {
+            "word": partition["word"].astype("string[pyarrow]"),
+            "token": (cupy.arange(len(partition), dtype="int32") + int(offset)),
+        }
+    )
 
 
 def _generate_vocab(
@@ -44,14 +64,66 @@ def _generate_vocab(
       across partitions before resetting the index.
     """
     if multi_gpu:
-        # construct word2idx
-        vocabulary = dd.concat(
+        # Build word2idx via hash-partition + per-partition arange.
+        #
+        # The previous approach was `concat(s, p, o).unique()` followed by
+        # `vocabulary_df.categorize(columns=["word"])`, which funnels the full
+        # deduplicated vocabulary onto a single worker for `sort_values()`. On
+        # Wikidata-scale graphs (~390 M unique tokens) that single-worker sort
+        # exceeds 40 GB of intermediate state and either OOMs the GPU or hangs
+        # the worker. The replacement is embarrassingly parallel:
+        #
+        #   1. concat(s, p, o) into a single `word` column (still lazy)
+        #   2. shuffle by `hash(word)` so identical strings co-locate on the
+        #      same partition
+        #   3. drop_duplicates() locally per partition — globally unique by
+        #      construction
+        #   4. persist so the follow-up `sizes.compute()` and per-partition id
+        #      assignment see the *same* shuffle output (without persist, the
+        #      shuffle re-rolls and partition assignments drift — we observed
+        #      23 M → 15 M row loss between sizes.compute and the eventual
+        #      write)
+        #   5. compute partition sizes (a tiny cumsum payload) → per-partition
+        #      offsets
+        #   6. dask.delayed(_assign_ids) per partition: `cupy.arange + offset`
+        #      gives globally-unique int32 token ids without any cross-
+        #      partition shuffle
+        n_hash_partitions = max(1, edge_df.npartitions)
+        vocabulary_df = dd.concat(
             [edge_df["subject"], edge_df["predicate"], edge_df["object"]]
-        ).unique()
-        vocabulary_df = vocabulary.to_frame(name="word")
-        word2idx = vocabulary_df.categorize(columns=["word"])
-        word2idx["token"] = word2idx["word"].cat.codes
-        word2idx = word2idx.astype({"word": "string[pyarrow]"})
+        ).to_frame(name="word")
+        vocabulary_df = vocabulary_df.shuffle(
+            on="word",
+            npartitions=n_hash_partitions,
+            shuffle_method="tasks",
+        )
+        vocabulary_df = vocabulary_df.drop_duplicates()
+        # Persist so the follow-up `sizes.compute()` and per-partition id
+        # assignment see the *same* shuffle output. The subsequent `compute()`
+        # on partition sizes drains the persist, so an explicit
+        # `distributed.wait` is unnecessary (and would require an active
+        # Client, breaking unit tests that use the default synchronous
+        # scheduler).
+        vocabulary_df = vocabulary_df.persist()
+
+        sizes = vocabulary_df.map_partitions(len).compute()
+        offsets = [0]
+        for s in sizes[:-1]:
+            offsets.append(offsets[-1] + int(s))
+
+        word2idx_meta = cudf.DataFrame(
+            {
+                "word": cudf.Series([], dtype="string[pyarrow]"),
+                "token": cudf.Series([], dtype="int32"),
+            }
+        )
+        delayed_parts = [
+            dask.delayed(_assign_ids)(
+                vocabulary_df.get_partition(i), offsets[i]
+            )
+            for i in range(vocabulary_df.npartitions)
+        ]
+        word2idx = dask_cudf.from_delayed(delayed_parts, meta=word2idx_meta)
         edge_df = (
             edge_df.merge(word2idx, left_on="subject", right_on="word")
             .drop(["word", "subject"], axis=1)

--- a/src/rdf2vecgpu/helper/functions.py
+++ b/src/rdf2vecgpu/helper/functions.py
@@ -124,20 +124,27 @@ def _generate_vocab(
             for i in range(vocabulary_df.npartitions)
         ]
         word2idx = dask_cudf.from_delayed(delayed_parts, meta=word2idx_meta)
+
+        # Encode the three edge columns by broadcast-joining word2idx into the
+        # edge table. The previous code used three plain `.merge()` calls
+        # without `broadcast=True`, which default to a hash-shuffle join; with
+        # a small word2idx partition count, the 1.38 B-row edge side gets
+        # funneled through one worker (we observed 6+ hours at 100 % on a
+        # single GPU with no progress). `broadcast=True` replicates the small
+        # word2idx to every worker, so each edge partition does a local hash
+        # join — no shuffle of the large side, one hash-table build per worker
+        # per merge instead of one per partition.
+        w2i_s = word2idx.rename(columns={"word": "subject", "token": "s_tok"})
+        w2i_p = word2idx.rename(columns={"word": "predicate", "token": "p_tok"})
+        w2i_o = word2idx.rename(columns={"word": "object", "token": "o_tok"})
         edge_df = (
-            edge_df.merge(word2idx, left_on="subject", right_on="word")
-            .drop(["word", "subject"], axis=1)
-            .rename(columns={"token": "subject"})
+            edge_df
+            .merge(w2i_s, on="subject", broadcast=True)
+            .merge(w2i_p, on="predicate", broadcast=True)
+            .merge(w2i_o, on="object", broadcast=True)
         )
-        edge_df = (
-            edge_df.merge(word2idx, left_on="predicate", right_on="word")
-            .drop(["word", "predicate"], axis=1)
-            .rename(columns={"token": "predicate"})
-        )
-        edge_df = (
-            edge_df.merge(word2idx, left_on="object", right_on="word")
-            .drop(["word", "object"], axis=1)
-            .rename(columns={"token": "object"})
+        edge_df = edge_df[["s_tok", "p_tok", "o_tok"]].rename(
+            columns={"s_tok": "subject", "p_tok": "predicate", "o_tok": "object"}
         )
         edge_df = edge_df.astype(
             {"subject": "int32", "predicate": "int32", "object": "int32"}

--- a/test/helper/functions_test.py
+++ b/test/helper/functions_test.py
@@ -71,6 +71,92 @@ def test_generate_vocab_multi_gpu():
     assert vocab.compute().shape == (4, 2)
 
 
+def _make_larger_dask_cudf_df(npartitions: int = 4):
+    """A 12-row triple table chosen so the unique vocab is exactly 11 strings.
+
+    Used to exercise the multi-GPU vocab build with multiple hash partitions.
+    The vocab is intentionally larger than `npartitions` so the cumsum-offset
+    arithmetic actually has multiple non-empty partitions to stitch together.
+    """
+    return dask_cudf.from_cudf(
+        cudf.DataFrame(
+            {
+                "subject": cudf.Series(
+                    ["A", "B", "C", "D", "E", "F", "A", "B", "C", "D", "E", "F"]
+                ),
+                "predicate": cudf.Series(
+                    ["p1", "p2", "p3", "p1", "p2", "p3", "p1", "p2", "p3", "p1", "p2", "p3"]
+                ),
+                "object": cudf.Series(
+                    ["X", "Y", "Z", "X", "Y", "Z", "Y", "Z", "X", "Z", "X", "Y"]
+                ),
+            }
+        ),
+        npartitions=npartitions,
+    )
+
+
+@pytest.mark.gpu
+def test_generate_vocab_multi_gpu_unique_tokens_contiguous_range():
+    """Every (word, token) pair is unique and tokens form a contiguous [0, n).
+
+    Catches off-by-one in the per-partition cumsum offsets — if any partition's
+    `_assign_ids` started at the wrong offset, tokens would either collide
+    (overlap) or skip ids (gap), breaking contiguity.
+    """
+    edge_df = _make_larger_dask_cudf_df(npartitions=4)
+    _, vocab_dd = _generate_vocab(edge_df, multi_gpu=True)
+    vocab = vocab_dd.compute()
+    # Vocab is the union of {A..F, p1..p3, X..Z} = 12 unique strings.
+    expected_words = {"A", "B", "C", "D", "E", "F", "p1", "p2", "p3", "X", "Y", "Z"}
+    assert set(vocab["word"].to_pandas()) == expected_words
+    # Token ids are unique.
+    tokens = sorted(vocab["token"].to_pandas().tolist())
+    assert len(tokens) == len(set(tokens)), "duplicate token ids"
+    # Token ids form a contiguous [0, n) range.
+    assert tokens == list(range(len(tokens)))
+
+
+@pytest.mark.gpu
+def test_generate_vocab_multi_gpu_round_trip_decodes_to_original_strings():
+    """edge_df decoded back through word2idx equals the original triple set.
+
+    Catches drift where the broadcast merges or the per-partition reshape
+    silently lose rows (e.g. if `drop_duplicates` got re-rolled without
+    persist, or a broadcast merge dropped non-matching rows).
+    """
+    original = _make_larger_dask_cudf_df(npartitions=4).compute().reset_index(drop=True)
+    encoded_dd, vocab_dd = _generate_vocab(
+        _make_larger_dask_cudf_df(npartitions=4), multi_gpu=True
+    )
+    encoded = encoded_dd.compute().reset_index(drop=True)
+    vocab = vocab_dd.compute()
+
+    # Build a token → word lookup from the materialized vocab.
+    token_to_word = dict(
+        zip(vocab["token"].to_pandas().tolist(), vocab["word"].to_pandas().tolist())
+    )
+    decoded_subject = encoded["subject"].to_pandas().map(token_to_word).tolist()
+    decoded_predicate = encoded["predicate"].to_pandas().map(token_to_word).tolist()
+    decoded_object = encoded["object"].to_pandas().map(token_to_word).tolist()
+
+    decoded_triples = set(zip(decoded_subject, decoded_predicate, decoded_object))
+    original_triples = set(
+        zip(
+            original["subject"].to_pandas().tolist(),
+            original["predicate"].to_pandas().tolist(),
+            original["object"].to_pandas().tolist(),
+        )
+    )
+    assert decoded_triples == original_triples, (
+        f"decoded triples differ from original; "
+        f"missing={original_triples - decoded_triples}, "
+        f"unexpected={decoded_triples - original_triples}"
+    )
+    # Row count preserved (no row loss from broadcast merges).
+    assert len(encoded) == len(original)
+
+
 def test_cudf_to_torch_tensor():
     cudf_df = _make_cudf_df()
     tensor = cudf_to_torch_tensor(cudf_df, "word")


### PR DESCRIPTION
## Summary

  Two coordinated commits in `_generate_vocab`'s multi-GPU path that together
  turn the never-completes Wikidata-scale vocab build into ~13 min vocab + ~3-5 h
  encode on 2× RTX A6000.

  ### Bugs fixed / scaling ceilings removed

  1. **Vocab build single-worker funnel.** `dd.concat(s, p, o).unique()` followed
     by `vocabulary_df.categorize(columns=["word"])` forces the full deduplicated
     vocabulary onto a single worker for `sort_values()`. On Wikidata (~390 M
     unique tokens) the single-worker sort exceeds 40 GB of intermediate state
     and either OOMs the GPU or hangs the worker.
  2. **Vocab build silent row drift.** The old path read the deduped output
     multiple times (sizes pass + write); without `.persist()` between, dask
     re-rolls the shuffle non-deterministically. The standalone tool that
     pioneered the fix observed 23 M → 15 M row loss between the sizes
     compute and the eventual write.
  3. **Encode-side merge funnel.** The three `.merge()` calls that join
     `word2idx` into the edge table didn't specify `broadcast=True`. Without it,
     dask defaults to a hash-shuffle join; the 1.38 B-row edge side gets
     funneled through a single worker (observed 6+ hours at 100 % single-GPU
     utilization with no progress).

  ### How

  **Commit 1 — `vocab: hash-partition rewrite (replaces categorize funnel)`:**
  replaces the concat→unique→categorize funnel with the embarrassingly-parallel
  pattern from `tools/vocab_hash_partition.py`:

    1. `dd.concat(s, p, o).to_frame("word")`
    2. `.shuffle(on="word", shuffle_method="tasks")` — identical strings co-locate
    3. `.drop_duplicates()` — local per-partition dedup, globally unique
    4. `.persist()` — pins the shuffle output before downstream reads
    5. `map_partitions(len).compute()` → per-partition cumsum offsets
    6. `dask.delayed(_assign_ids)` per partition: `cupy.arange + offset` →
       globally-unique int32 token ids, no cross-partition shuffle

  **Commit 2 — `encode: broadcast=True on word2idx merges`:** changes the three
  edge-side merges to `broadcast=True`, replicating the small `word2idx` to every
  worker so each edge partition does a local hash join with no shuffle of the
  large side. Pre-renames to `s_tok`/`p_tok`/`o_tok` to avoid intermediate column
  collisions; final select + rename restores the `[subject, predicate, object]`
  schema. Tests + CHANGELOG bundled into this commit.

  ## Test plan

  - [x] `pytest --gpu test/helper/functions_test.py` — all 6 tests pass on GPU
        (1× RTX 2080 Ti, 6.6s):
    - 4 pre-existing tests (single-GPU, multi-GPU smoke, tensor conversion)
    - **NEW:** `test_generate_vocab_multi_gpu_unique_tokens_contiguous_range` —
      catches off-by-one in cumsum offsets
    - **NEW:** `test_generate_vocab_multi_gpu_round_trip_decodes_to_original_strings` —
      catches row drift from broadcast merges or unstable shuffles
  - [x] **Wikidata sliver smoke** — 10 input partitions out of 256 (~4 % of full
        Wikidata, 319 M edges) on 2× A6000. `_generate_vocab` ran end-to-end
        through the public library API in **127.7 s**, producing **93.78 M unique
        tokens** with all four invariants holding:
    - encoded row count == input row count (319,175,810) — broadcast merges
      didn't drop any rows
    - vocab tokens form contiguous `[0, 93_778_289)` — cumsum offsets correct
    - all 93.78 M vocab rows have unique words — `drop_duplicates` stable
    - encoded columns are int32 — dtype contract preserved
    Linear extrapolation to the full 1.38 B-edge Wikidata graph: ~9-13 min vocab
    build, matching the standalone tool's recorded baseline in
    `decision_log/004`.

  ## Notes

  - No public API changes. `_generate_vocab(edge_df, multi_gpu) → (edge_df, word2idx)`
    signature and column ordering preserved (`vocab.columns == ["word", "token"]`,
    `edge_df.columns == ["subject", "predicate", "object"]`).
  - No version bump in this PR — per the bundle-into-0.4.0 release plan, all four
    PRs in the upstream-port sequence (PR1 walks, PR2 vocab/encode, PR3 docs,
    PR4 gensim trainer) ship together as `v0.4.0`. CHANGELOG entries land in
    `## [Unreleased]` and graduate when `v0.4.0` is tagged.
  - The early draft of commit 1 used `dask.distributed.wait()` after `.persist()`
    (mirroring `tools/walk_gen.py`'s pattern), which broke unit tests because
    `wait()` requires an active `distributed.Client`. Removed since the