### PR TITLE
Feat/gensim trainer backend + v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] — 2026-04-27
+
+This release bundles a four-PR upstream-port sequence that ports
+Wikidata-scale fixes and a new optional gensim training backend back into
+the library. The pipeline now scales to the 1.38 B-edge / 390 M-vertex
+Wikidata graph end-to-end on 2× RTX A6000.
 
 ### Added
 
+- **Optional gensim Word2Vec backend.** New
+  `backend="gensim"` config field on `RDF2VecConfig` (alongside the
+  default `"pytorch"`); `GPU_RDF2Vec.fit()` dispatches on it. The gensim
+  path consumes walks-as-sequences via streaming parquet
+  (`pyarrow.parquet.ParquetFile.iter_batches`) and trains via
+  `gensim.models.Word2Vec`'s C-level negative-sampling loop — typically
+  5–10× faster on CPU than the equivalent PyTorch skip-gram on the same
+  corpus, with constant-memory streaming on multi-billion-walk corpora.
+  Opt in via `pip install rdf2vecgpu[gensim]`.
+- `embedders/gensim_word2vec.py` — new module with three exports:
+  - `WalkCorpus`: streaming parquet iterator over walk sequences (trims
+    cuGraph `-1` sentinels, skips walks with <2 valid vertices).
+  - `load_id_to_word`: scatters `_generate_vocab`'s contiguous token range
+    into a numpy object array indexed by token (avoids the ~45 GB
+    Python-dict overhead the original gensim recipe measured at Wikidata
+    scale).
+  - `train_gensim_word2vec`: thin wrapper around `gensim.models.Word2Vec`
+    forwarding the relevant `RDF2VecConfig` fields.
+- `_walks_to_lists` helper in `corpus/walk_corpus.py` — sister to
+  `_build_walk_steps` (added in this release) that emits per-walk rows
+  with `vertices: list<int>` + `predicates: list<int>` columns. Used by
+  the new `random_walk_sequences()` methods on both `SingleGPUWalkCorpus`
+  and `MultiGPUWalkCorpus`.
+- `GPU_RDF2Vec.walk_generation_sequences()` and
+  `GPU_RDF2Vec._fit_via_gensim()` orchestration methods on the main
+  pipeline class.
 - `_build_walk_steps(vertices_s, edge_attrs_s, walk_length, walk_id_offset)`
   in `rdf2vecgpu.corpus.walk_corpus` — a per-partition reshape helper that
   consumes cuGraph's flat `(vertices, edge_attrs)` walk output and emits
@@ -28,6 +59,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (catches row drift from broadcast merges or unstable shuffles).
 - `gpu` pytest marker registered in `pyproject.toml`'s
   `[tool.pytest.ini_options]`.
+- `test/embedders/gensim_word2vec_test.py` — CPU-only tests for the
+  new gensim backend (streaming `WalkCorpus` semantics, sentinel
+  trimming, contiguous-token guard in `load_id_to_word`, end-to-end
+  smoke through `train_gensim_word2vec`). Skipped at module import if
+  the `gensim` extra isn't installed.
+- `[project.optional-dependencies].gensim` group in `pyproject.toml`
+  (`gensim>=4.3.0`, `pyarrow>=15`).
 
 ### Documentation
 
@@ -39,8 +77,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `helper/functions.py`. Also documents the two `_compat` patches
   (`_patch_convert_to_cudf` and `_patch_dask_cudf_from_cudf`) and notes
   that the long-term fix for both is upstream in cuGraph / dask-cudf.
-- Roadmap entry for the planned optional gensim Word2Vec trainer
-  backend (`train_backend="gensim"`).
+- Roadmap entry for the optional gensim Word2Vec trainer backend
+  (now shipped in this same `0.4.0` — see "Optional gensim Word2Vec
+  backend" under Added).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -292,13 +292,14 @@ The overview of the used MIT license can be found [here](LICENSE)
 - [ ] Provide spilling to single GPU training to work around potential OOM issues faced during rdf2vec training [Issue Item](https://github.com/MartinBoeckling/rdf2vecgpu/issues/3)
 - [X] Provide weighted walks for spatial datasets [Issue item](https://github.com/MartinBoeckling/rdf2vecgpu/issues/4)
 - [X] Provide logging capabilities of complete Word2Vec pipeline for [Wandb](https://wandb.ai/site/) and [mlflow](https://mlflow.org/). [Issue item](https://github.com/MartinBoeckling/rdf2vecgpu/issues/5)
-- [ ] Optional gensim Word2Vec trainer backend (`train_backend="gensim"`)
+- [X] Optional gensim Word2Vec trainer backend (`backend="gensim"`)
   alongside the default PyTorch Lightning trainer. The gensim C path is
   5–10× faster on CPU for very large corpora (~390 M-token vocab,
   multi-billion walks) and supports constant-memory streaming via
   `pyarrow.parquet.ParquetFile.iter_batches`. Useful when running on a
   CPU-rich + GPU-light box where the PyTorch trainer is bottlenecked on
-  data movement rather than compute.
+  data movement rather than compute. Shipped in `v0.4.0`; opt in via
+  `pip install rdf2vecgpu[gensim]` and `RDF2VecConfig(backend="gensim")`.
 
 ## Report issues and bugs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rdf2vecgpu"
-version = "0.3.0"
+version = "0.4.0"
 description = "GPU-Accelerated RDF2Vec – A high-performance GPU implementation of RDF2Vec that uses CUDA and RAPIDS to generate scalable, embeddings for large dense knowledge graphs."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ mlflow = [
 wandb = [
     "wandb>=0.23.0",
 ]
+gensim = [
+    "gensim>=4.3.0",
+    "pyarrow>=15",
+]
 test = [
     "pytest>=9.0.1",
     "pytest-cov>=7.0.0",

--- a/src/rdf2vecgpu/corpus/walk_corpus.py
+++ b/src/rdf2vecgpu/corpus/walk_corpus.py
@@ -15,6 +15,49 @@ import torch
 # (concat, sort_values, merge, groupby, rename, assign) is identical.
 
 
+def _walks_to_lists(vertices_s, edge_attrs_s, walk_length):
+    """Reshape cuGraph's flat random-walk output into per-walk list rows.
+
+    Sister helper to `_build_walk_steps`: same input contract, but emits one
+    row per walk with `vertices: list<int>` + `predicates: list<int>` columns
+    instead of per-step rows. This matches the schema gensim's `WalkCorpus`
+    streaming iterator consumes (see `embedders.gensim_word2vec.WalkCorpus`)
+    and the schema `tools/walk_gen.py` uses for parquet output.
+
+    Like `_build_walk_steps`, the input partitions must hold an integer
+    multiple of (walk_length + 1) vertex elements (cuGraph's dask API
+    guarantees this alignment when emitting walks).
+
+    Walks shorter than `walk_length` are padded with cuGraph's `-1` sentinel;
+    we keep those `-1` cells in the lists so the gensim walk-streaming
+    iterator can trim them at first occurrence (matches the standalone
+    tool's behavior).
+    """
+    stride_v = walk_length + 1
+    stride_p = walk_length
+    n_walks = len(vertices_s) // stride_v
+    if n_walks * stride_v != len(vertices_s):
+        raise ValueError(
+            f"vertex partition size {len(vertices_s)} is not a multiple of "
+            f"walk stride {stride_v}; cuGraph's walk output is expected to be "
+            f"stride-aligned"
+        )
+    if len(edge_attrs_s) != n_walks * stride_p:
+        raise ValueError(
+            f"edge_attrs partition size {len(edge_attrs_s)} does not match "
+            f"expected {n_walks * stride_p} (n_walks={n_walks}, "
+            f"walk_length={walk_length})"
+        )
+    vs = cp.asarray(vertices_s.values).reshape(n_walks, stride_v)
+    ps = cp.asarray(edge_attrs_s.values).reshape(n_walks, stride_p)
+    return cudf.DataFrame(
+        {
+            "vertices": cudf.Series(vs.tolist()),
+            "predicates": cudf.Series(ps.tolist()),
+        }
+    )
+
+
 def _build_walk_steps(vertices_s, edge_attrs_s, walk_length, walk_id_offset=0):
     """Reshape cuGraph's flat random-walk output into per-step rows.
 
@@ -302,6 +345,33 @@ class SingleGPUWalkCorpus:
         tokens = _triples_to_tokens(merged_walks, min_count, concat_fn=cudf.concat)
         return _dispatch_pairs(tokens, self.window_size, word2vec_model, concat_fn=cudf.concat)
 
+    def random_walk_sequences(
+        self,
+        walk_vertices: cudf.Series,
+        walk_depth: int,
+        random_state: int,
+    ) -> cudf.DataFrame:
+        """Walks-as-sequences output (vertices + predicates list columns).
+
+        Sister method to `random_walk` for the gensim training backend, which
+        wants raw walk sequences (it builds its own skip-gram windows
+        internally). Output schema:
+            vertices   : list<int32>   length = walk_depth + 1
+            predicates : list<int32>   length = walk_depth
+
+        Walks shorter than `walk_depth` keep cuGraph's `-1` sentinel slots in
+        the lists so the gensim streaming iterator can trim them at first
+        occurrence.
+        """
+        walk_fn = biased_random_walks if self.walk_weighted else uniform_random_walks
+        random_walks, edge_attrs, max_length = walk_fn(
+            self.G,
+            start_vertices=walk_vertices,
+            max_depth=walk_depth,
+            random_state=random_state,
+        )
+        return _walks_to_lists(random_walks, edge_attrs, walk_length=int(max_length))
+
 
 # ── Multi-GPU Walk Corpus ───────────────────────────────────────────────────
 
@@ -424,6 +494,69 @@ class MultiGPUWalkCorpus:
         tokens = _triples_to_tokens(merged, min_count, concat_fn=dcudf.concat)
         pairs = _dispatch_pairs(tokens, self.window_size, word2vec_model, concat_fn=dcudf.concat)
         return pairs
+
+    def random_walk_sequences(
+        self,
+        walk_vertices,
+        walk_depth: int,
+        random_state: int,
+    ):
+        """Multi-GPU walks-as-sequences output (vertices + predicates list cols).
+
+        Sister method to `random_walk` for the gensim training backend. Returns
+        a `dask_cudf.DataFrame` with one row per walk and `vertices` / `predicates`
+        list columns; mirrors the parquet schema produced by `tools/walk_gen.py`,
+        which is what `embedders.gensim_word2vec.WalkCorpus` consumes.
+        """
+        if isinstance(walk_vertices, dcudf.Series):
+            start_vertices = walk_vertices
+        else:
+            start_vertices = _ensure_dask_frame(
+                cudf.DataFrame({"v": walk_vertices})
+            )["v"]
+
+        walk_fn = dask_biased_random_walks if self.walk_weighted else dask_uniform_random_walks
+        walk_label = "biased" if self.walk_weighted else "uniform"
+        logger.info(
+            f"Running multi-GPU {walk_label}_random_walks (sequences output) …"
+        )
+        from dask.distributed import wait as dask_wait
+
+        walks_s, edge_attrs_s, max_len = walk_fn(
+            self.G,
+            start_vertices=start_vertices,
+            max_depth=walk_depth,
+        )
+        walk_length = int(max_len)
+        # Persist + wait so the reshape sees a stable walks output (uniform_random_walks
+        # is stochastic).
+        walks_s = walks_s.persist()
+        edge_attrs_s = edge_attrs_s.persist()
+        dask_wait([walks_s, edge_attrs_s])
+
+        # Combine the two aligned series partition-wise; each partition emits
+        # one row per walk.
+        meta = cudf.DataFrame(
+            {
+                "vertices": cudf.Series([], dtype="object"),
+                "predicates": cudf.Series([], dtype="object"),
+            }
+        )
+        walks_delayed = walks_s.to_delayed()
+        edges_delayed = edge_attrs_s.to_delayed()
+        if len(walks_delayed) != len(edges_delayed):
+            raise RuntimeError(
+                f"vertex/edge_attr partition layout drift: "
+                f"{len(walks_delayed)} vs {len(edges_delayed)}"
+            )
+        parts = [
+            dask.delayed(_walks_to_lists)(walks_delayed[i], edges_delayed[i], walk_length)
+            for i in range(len(walks_delayed))
+        ]
+        sequences = dcudf.from_delayed(parts, meta=meta)
+        sequences = sequences.persist()
+        dask_wait(sequences)
+        return sequences
 
     def bfs_walk(
         self,

--- a/src/rdf2vecgpu/embedders/gensim_word2vec.py
+++ b/src/rdf2vecgpu/embedders/gensim_word2vec.py
@@ -1,0 +1,263 @@
+"""Optional gensim Word2Vec backend for the RDF2Vec training stage.
+
+Mirrors `tools/train_gensim.py` from the upstream Wikidata calibration runs
+but lives inside the library so `GPU_RDF2Vec(config=RDF2VecConfig(
+backend="gensim")).fit(...)` works end-to-end.
+
+Why this exists alongside the default PyTorch trainer:
+
+* gensim's C-level negative-sampling Word2Vec is typically 5-10× faster on CPU
+  than the equivalent PyTorch skip-gram loop on the same corpus.
+* `pyarrow.parquet.ParquetFile.iter_batches` keeps memory constant while
+  streaming multi-billion-walk corpora; the PyTorch path materializes the
+  whole corpus to GPU.
+* For users running CPU-rich + GPU-light boxes (e.g. a single A6000 + a
+  large NUMA box for training), the gensim path frees the GPU after walk
+  generation and lets the CPU do the training work.
+
+This module is gated behind the `gensim` optional-dependency group:
+    pip install rdf2vecgpu[gensim]
+"""
+from __future__ import annotations
+
+import glob
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+# gensim and pyarrow are optional dependencies. Import lazily so users on the
+# default pytorch backend don't need them installed; raise a friendly error
+# only when the gensim path is actually invoked.
+try:
+    import pyarrow.parquet as pq
+    from gensim.models import Word2Vec
+
+    _GENSIM_AVAILABLE = True
+    _GENSIM_IMPORT_ERROR: Exception | None = None
+except ImportError as exc:  # pragma: no cover - optional dep
+    _GENSIM_AVAILABLE = False
+    _GENSIM_IMPORT_ERROR = exc
+
+if TYPE_CHECKING:
+    from gensim.models import KeyedVectors  # noqa: F401
+
+
+def _require_gensim() -> None:
+    if not _GENSIM_AVAILABLE:
+        raise ImportError(
+            "The gensim training backend requires `gensim` and `pyarrow`. "
+            "Install with: pip install rdf2vecgpu[gensim] "
+            f"(original import error: {_GENSIM_IMPORT_ERROR!r})"
+        )
+
+
+def load_id_to_word(word2idx_df) -> np.ndarray:
+    """Convert word2idx → numpy object array indexed by int32 token.
+
+    `_generate_vocab` produces tokens as a contiguous `[0, n)` range, so we
+    scatter the word column into a dense numpy object array indexed by token.
+    Avoids the ~45 GB Python-dict overhead the standalone tool's first-version
+    used; numpy fancy-indexing (`arr[[1,2,3]]`) is one vectorised call per walk.
+    """
+    if hasattr(word2idx_df, "compute"):
+        # dask_cudf.DataFrame
+        word2idx_df = word2idx_df.compute()
+    if hasattr(word2idx_df, "to_pandas"):
+        # cudf.DataFrame
+        word2idx_df = word2idx_df.to_pandas()
+    tokens = word2idx_df["token"].to_numpy()
+    n = int(tokens.max()) + 1
+    if n != len(tokens):
+        raise ValueError(
+            f"word2idx tokens are not contiguous [0, n) "
+            f"(rows={len(tokens):,}, max={n - 1:,})"
+        )
+    words = np.empty(n, dtype=object)
+    words[tokens] = word2idx_df["word"].to_numpy()
+    return words
+
+
+class WalkCorpus:
+    """Stream walks-parquet → interleaved URI sequences for gensim.
+
+    Each parquet file under `walks_dir` has columns
+        vertices   : list<int>   length = walk_depth + 1
+        predicates : list<int>   length = walk_depth
+    written by `MultiGPUWalkCorpus.random_walk_sequences` (or by the standalone
+    `tools/walk_gen.py`). This iterator emits interleaved sequences
+    `[v0, p0, v1, p1, v2, ..., v_n]` per walk — the format gensim's
+    `Word2Vec(sentences=...)` constructor consumes.
+
+    cuGraph emits `-1` for vertex slots past the walk's actual end (dead-end
+    hit before max_depth). We trim each walk at the first `-1` and keep the
+    matching predicate prefix; walks with fewer than 2 valid vertices are
+    skipped (need at least one edge for skip-gram).
+    """
+
+    def __init__(
+        self,
+        walks_dir: str,
+        id_to_word: np.ndarray | None,
+        batch_size: int = 20_000,
+        int_tokens: bool = False,
+    ):
+        _require_gensim()
+        self.walks_dir = walks_dir
+        self.id_to_word = id_to_word
+        self.batch_size = batch_size
+        self.int_tokens = int_tokens
+        # Both the flat layout (`*.parquet`) and any nested layout
+        # (`**/*.parquet`) are supported.
+        files = sorted(
+            glob.glob(f"{walks_dir}/*.parquet")
+            + glob.glob(f"{walks_dir}/**/*.parquet", recursive=True)
+        )
+        self.files = sorted(set(files))
+        if not self.files:
+            raise FileNotFoundError(f"no parquet files under {walks_dir}")
+        if id_to_word is None and not int_tokens:
+            raise ValueError(
+                "id_to_word is required when int_tokens=False; pass the "
+                "word2idx mapping or set int_tokens=True"
+            )
+
+    def __iter__(self):
+        id_to_word = self.id_to_word
+        int_tokens = self.int_tokens
+        for f in self.files:
+            pf = pq.ParquetFile(f)
+            for batch in pf.iter_batches(
+                columns=["vertices", "predicates"], batch_size=self.batch_size
+            ):
+                # Convert list<int> columns once per batch, not per walk.
+                vs = batch.column("vertices").to_pylist()
+                ps = batch.column("predicates").to_pylist()
+                for walk_v, walk_p in zip(vs, ps):
+                    end = next(
+                        (i for i, v in enumerate(walk_v) if v < 0),
+                        len(walk_v),
+                    )
+                    if end < 2:
+                        continue
+                    walk_v = walk_v[:end]
+                    walk_p = walk_p[: end - 1]
+                    if int_tokens:
+                        v_words = [str(int(v)) for v in walk_v]
+                        p_words = [str(int(p)) for p in walk_p]
+                    else:
+                        v_words = id_to_word[walk_v].tolist()
+                        # Predicates may come back as float (cuGraph edge-weight
+                        # slot is float-typed); cast to int for fancy-indexing.
+                        p_words = id_to_word[[int(p) for p in walk_p]].tolist()
+                    out: list[Any] = [None] * (len(walk_v) + len(walk_p))
+                    out[0::2] = v_words
+                    out[1::2] = p_words
+                    yield out
+
+
+def kv_to_token_aligned_matrix(kv, word2idx_df) -> np.ndarray:
+    """Reshape a `gensim.models.KeyedVectors` into a token-indexed matrix.
+
+    Used by `gpu_rdf2vec._extract_embeddings_gensim` to materialize the
+    `[token, word, embedding_*]` schema the PyTorch path produces. Built as
+    a separate pure-numpy helper so its row-alignment invariants can be
+    unit-tested without a GPU (the cudf concat that follows is
+    GPU-dependent).
+
+    Behaviour:
+
+    * Each row `i` of the returned matrix is the embedding for token id `i`.
+      Tokens are assumed contiguous `[0, n)` (guaranteed by `_generate_vocab`);
+      `n_tokens` is derived from `max(token) + 1`.
+    * If gensim trained with `int_tokens=True` (default in the library), the
+      KV's `.index_to_key` entries are stringified ints and we use them
+      directly. If `int_tokens=False`, keys are URI strings and we fall back
+      to looking each one up in `word2idx_df` — slower but correct.
+    * Tokens that gensim's `min_count` filter dropped from the KV vocab get
+      a zero row in the output. This is intentional but lossy at
+      `min_count > 1`; callers may want to log a warning when
+      `len(kv.index_to_key) < n_tokens`.
+    """
+    if hasattr(word2idx_df, "compute"):
+        word2idx_df = word2idx_df.compute()
+    if hasattr(word2idx_df, "to_pandas"):
+        word2idx_df = word2idx_df.to_pandas()
+    n_tokens = int(word2idx_df["token"].max()) + 1
+    vectors = np.zeros((n_tokens, kv.vector_size), dtype=np.float32)
+    for key in kv.index_to_key:
+        try:
+            tok = int(key)
+        except (TypeError, ValueError):
+            row = word2idx_df[word2idx_df["word"] == key]
+            if row.empty:
+                continue
+            tok = int(row["token"].iloc[0])
+        if 0 <= tok < n_tokens:
+            vectors[tok] = kv[key]
+    return vectors
+
+
+def train_gensim_word2vec(
+    walks_dir: str,
+    word2idx_df,
+    *,
+    vector_size: int,
+    window: int,
+    min_count: int,
+    embedding_model: str = "skipgram",
+    negative: int = 5,
+    epochs: int = 5,
+    workers: int = 4,
+    learning_rate: float = 0.025,
+    random_state: int = 42,
+    batch_size: int = 20_000,
+    int_tokens: bool = True,
+):
+    """Fit a gensim `Word2Vec` model on a walks-parquet directory.
+
+    Returns the fitted `gensim.models.Word2Vec` model. Caller can pull
+    `.wv` (KeyedVectors) for downstream `transform()`.
+
+    Parameters
+    ----------
+    walks_dir : str
+        Path to a parquet directory written by
+        `MultiGPUWalkCorpus.random_walk_sequences` (or the equivalent
+        single-GPU output materialized to parquet).
+    word2idx_df : cudf.DataFrame | dask_cudf.DataFrame | pandas.DataFrame
+        The word2idx mapping (`word`, `token` columns). Required even when
+        `int_tokens=True` so the resulting embeddings can be joined back to
+        URIs in `transform()`.
+    vector_size, window, min_count, negative, epochs, workers, learning_rate,
+    random_state : int / float
+        Forwarded to `gensim.models.Word2Vec`.
+    embedding_model : {"skipgram", "cbow"}, default "skipgram"
+        Mapped to gensim's `sg=1` / `sg=0`.
+    int_tokens : bool, default True
+        Train on stringified int tokens instead of decoded URI strings. Saves
+        ~20 GB RAM on Wikidata-scale corpora at the cost of one post-training
+        join with `word2idx_df` to recover URI-keyed embeddings (handled in
+        `gpu_rdf2vec._fit_via_gensim`).
+    """
+    _require_gensim()
+    sg = 1 if embedding_model == "skipgram" else 0
+    id_to_word = None if int_tokens else load_id_to_word(word2idx_df)
+    corpus = WalkCorpus(
+        walks_dir,
+        id_to_word,
+        batch_size=batch_size,
+        int_tokens=int_tokens,
+    )
+    model = Word2Vec(
+        sentences=corpus,
+        vector_size=vector_size,
+        window=window,
+        min_count=min_count,
+        sg=sg,
+        negative=negative,
+        workers=workers,
+        epochs=epochs,
+        alpha=learning_rate,
+        seed=random_state,
+    )
+    return model

--- a/src/rdf2vecgpu/gpu_rdf2vec.py
+++ b/src/rdf2vecgpu/gpu_rdf2vec.py
@@ -505,6 +505,67 @@ class GPU_RDF2Vec:
 
         return walk_corpus
 
+    def walk_generation_sequences(
+        self, edge_df: cudf.DataFrame, walk_vertices: cudf.Series = None
+    ):
+        """Walks-as-sequences output for the gensim training backend.
+
+        Sister to `walk_generation`, but emits walks as parallel
+        `vertices: list<int>` + `predicates: list<int>` columns (one row per
+        walk) instead of pre-built (center, context) skip-gram pairs.
+        Gensim builds its own skip-gram windows internally, so it wants the
+        raw walk sequences, not pre-computed pairs.
+
+        Only the "random" walk strategy is supported for the gensim backend
+        in this release — bfs walks would need a parallel BFS-to-sequences
+        path on the corpus classes.
+        """
+        with self.tracker.stage("Walk_Generation"):
+            if self.config.multi_gpu:
+                walk_instance = MultiGPUWalkCorpus(
+                    self.knowledge_graph,
+                    self.config.window_size,
+                    walk_weighted=self.config.walk_weighted,
+                )
+            else:
+                walk_instance = SingleGPUWalkCorpus(
+                    self.knowledge_graph,
+                    self.config.window_size,
+                    walk_weighted=self.config.walk_weighted,
+                )
+            if self.config.walk_strategy != "random":
+                raise NotImplementedError(
+                    f"backend='gensim' currently supports walk_strategy='random' "
+                    f"only (got {self.config.walk_strategy!r}). bfs+gensim would "
+                    f"need a parallel sequences output on bfs_walk."
+                )
+            if walk_vertices is None:
+                walk_vertices = self.knowledge_graph.nodes()
+            n = self.config.walk_number
+            if hasattr(walk_vertices, "map_partitions"):
+                walk_vertices = walk_vertices.map_partitions(
+                    lambda s: s.repeat(n).reset_index(drop=True)
+                )
+            else:
+                walk_vertices = walk_vertices.repeat(n)
+            walk_sequences = walk_instance.random_walk_sequences(
+                walk_vertices=walk_vertices,
+                walk_depth=self.config.walk_depth,
+                random_state=self.config.random_state,
+            )
+            self.tracker.log_params(
+                {
+                    "walk_depth": self.config.walk_depth,
+                    "random_state": self.config.random_state,
+                    "walk_strategy": self.config.walk_strategy,
+                    "walk_number": self.config.walk_number,
+                    "walk_weighted": self.config.walk_weighted,
+                    "min_count": self.config.min_count,
+                    "backend": "gensim",
+                }
+            )
+        return walk_sequences
+
     def fit(self, edge_df: cudf.DataFrame, walk_vertices: cudf.Series = None) -> None:
         """
          Train a Word2Vec model on random-walk sequences generated from the
@@ -545,6 +606,15 @@ class GPU_RDF2Vec:
          >>> edges = rdf2vec.load_data("example.parquet")
          >>> rdf2vec.fit(edges)
         """
+        # backend dispatch: gensim consumes walks-as-sequences via parquet
+        # streaming and trains on CPU; pytorch consumes (center, context)
+        # skip-gram pairs and trains on GPU via Lightning.
+        if self.config.backend == "gensim":
+            walk_sequences = self.walk_generation_sequences(
+                edge_df=edge_df, walk_vertices=walk_vertices
+            )
+            self._fit_via_gensim(walk_sequences)
+            return
         walk_corpus = self.walk_generation(
             edge_df=edge_df,
             walk_vertices=walk_vertices,
@@ -583,6 +653,102 @@ class GPU_RDF2Vec:
             if hasattr(walk_corpus, "compute"):
                 walk_corpus = walk_corpus.compute()
             self._fit_from_tensors(walk_corpus)
+
+    def _fit_via_gensim(self, walk_sequences) -> None:
+        """Train Word2Vec via the optional gensim backend.
+
+        Materializes the walks-as-sequences corpus to a temp parquet directory
+        (gensim's streaming `WalkCorpus` iterator reads parquet files), tears
+        down the dask cluster if multi-GPU was used so the GPU memory is
+        released before CPU-side training, then fits gensim's
+        negative-sampling Word2Vec.
+
+        The trained gensim model is stored on `self.word2vec_model` (same
+        attribute the pytorch backend uses); `transform()` branches on
+        backend to extract embeddings into the standard `[token, word,
+        embedding_*]` cudf DataFrame.
+        """
+        from .embedders.gensim_word2vec import train_gensim_word2vec
+        import tempfile, shutil
+
+        with self.tracker.stage("Word2Vec_Training"):
+            walk_dir = tempfile.mkdtemp(prefix="rdf2vec_gensim_walks_")
+            try:
+                walks_parquet = f"{walk_dir}/walks"
+                logger.info(f"Checkpointing walk sequences to {walks_parquet}")
+                if hasattr(walk_sequences, "to_parquet"):
+                    # dask_cudf.DataFrame: each worker writes its partition.
+                    # `random_walk_sequences()` already persist+wait-ed the
+                    # walk output, but re-pin defensively here so a future
+                    # refactor that moves the persist out of the corpus class
+                    # doesn't silently re-roll the stochastic walk generator
+                    # on this `to_parquet`. Matches the explicit persist+wait
+                    # the PyTorch checkpoint path uses.
+                    from dask.distributed import wait as dask_wait
+
+                    walk_sequences = walk_sequences.persist()
+                    dask_wait(walk_sequences)
+                    walk_sequences.to_parquet(walks_parquet, write_index=False)
+                else:
+                    # cudf.DataFrame: single-file write under the directory.
+                    import os as _os
+                    _os.makedirs(walks_parquet, exist_ok=True)
+                    walk_sequences.to_parquet(
+                        f"{walks_parquet}/part.0.parquet", index=False
+                    )
+
+                # Free GPU resources before CPU-side gensim training. Mirrors
+                # the multi-GPU pytorch path's teardown so the gensim workers
+                # have full host RAM.
+                if self.config.multi_gpu:
+                    try:
+                        import cugraph.dask.comms.comms as Comms
+
+                        if Comms.is_initialized():
+                            Comms.destroy()
+                    except Exception:
+                        pass
+                    if self.client is not None:
+                        self.client.close()
+                        self.client = None
+                    logger.info(
+                        "Dask cluster shut down; starting gensim training"
+                    )
+
+                logger.info(
+                    f"Training gensim Word2Vec "
+                    f"(vector_size={self.config.vector_size}, "
+                    f"window={self.config.window_size}, "
+                    f"epochs={self.config.epochs}, "
+                    f"workers={self.config.cpu_count})"
+                )
+                gensim_model = train_gensim_word2vec(
+                    walks_dir=walks_parquet,
+                    word2idx_df=self.word2idx,
+                    vector_size=self.config.vector_size,
+                    window=self.config.window_size,
+                    min_count=self.config.min_count,
+                    embedding_model=self.config.embedding_model,
+                    negative=self.config.negative_samples,
+                    epochs=self.config.epochs,
+                    workers=self.config.cpu_count,
+                    learning_rate=self.config.learning_rate,
+                    random_state=self.config.random_state,
+                )
+                self.word2vec_model = gensim_model
+                self.tracker.log_params(
+                    {
+                        "vector_size": self.config.vector_size,
+                        "window_size": self.config.window_size,
+                        "epochs": self.config.epochs,
+                        "negative_samples": self.config.negative_samples,
+                        "embedding_model": self.config.embedding_model,
+                        "learning_rate": self.config.learning_rate,
+                        "backend": "gensim",
+                    }
+                )
+            finally:
+                shutil.rmtree(walk_dir, ignore_errors=True)
 
     def _fit_from_parquet(self, walk_path: str) -> None:
         """Train Word2Vec from parquet shards using DDP across all GPUs."""
@@ -748,27 +914,81 @@ class GPU_RDF2Vec:
         """
         # Check if model is fitted and word2idx is available
         with self.tracker.stage("Embedding_Extraction"):
-            if self.word2vec_model is not None and self.word2idx is not None:
-                model_embeddings = self.word2vec_model.in_embeddings.weight.detach().cuda()
-                # Convert via CuPy to avoid cudf from_dlpack column-major requirement
-                import cupy as cp
-                cp_arr = cp.from_dlpack(model_embeddings)
-                model_embeddings_df = cudf.DataFrame(
-                    {str(i): cp_arr[:, i] for i in range(cp_arr.shape[1])}
-                )
-                model_embeddings_df.columns = model_embeddings_df.columns.astype(str)
-                model_embeddings_df = model_embeddings_df.add_prefix("embedding_")
-                embedding_df = cudf.concat([self.word2idx, model_embeddings_df], axis=1)
-                if self.config.generate_artifact:
-                    embedding_df.to_parquet(
-                        f"vector/embeddings_{self.config.embedding_model}.parquet", index=False
-                    )
-                return embedding_df
-            else:
+            if self.word2vec_model is None or self.word2idx is None:
                 raise ValueError(
                     "The transform method is not possible to call without a fitted model or a generated word2idx setup. "
                     "Please call the 'fit' method first or the 'load_data' method to generate the word2idx setup."
                 )
+            if self.config.backend == "gensim":
+                embedding_df = self._extract_embeddings_gensim()
+            else:
+                embedding_df = self._extract_embeddings_pytorch()
+            if self.config.generate_artifact:
+                embedding_df.to_parquet(
+                    f"vector/embeddings_{self.config.embedding_model}.parquet",
+                    index=False,
+                )
+            return embedding_df
+
+    def _extract_embeddings_pytorch(self) -> cudf.DataFrame:
+        """Pull `[token, word, embedding_0..n]` cudf DataFrame from the
+        PyTorch trainer's in-embeddings weight matrix."""
+        import cupy as cp
+
+        model_embeddings = (
+            self.word2vec_model.in_embeddings.weight.detach().cuda()
+        )
+        # Convert via CuPy to avoid cudf from_dlpack column-major requirement
+        cp_arr = cp.from_dlpack(model_embeddings)
+        model_embeddings_df = cudf.DataFrame(
+            {str(i): cp_arr[:, i] for i in range(cp_arr.shape[1])}
+        )
+        model_embeddings_df.columns = model_embeddings_df.columns.astype(str)
+        model_embeddings_df = model_embeddings_df.add_prefix("embedding_")
+        return cudf.concat([self.word2idx, model_embeddings_df], axis=1)
+
+    def _extract_embeddings_gensim(self) -> cudf.DataFrame:
+        """Pull `[token, word, embedding_0..n]` cudf DataFrame from the
+        gensim KeyedVectors output.
+
+        Row alignment is delegated to
+        `embedders.gensim_word2vec.kv_to_token_aligned_matrix`, which is a
+        pure-numpy helper unit-tested separately. The cudf concat below joins
+        the resulting token-ordered matrix with a token-sorted `word2idx` so
+        each row is `[token, word, embedding_*]` for the same token id.
+
+        Note: gensim's `min_count` filter (when `min_count > 1`) drops tokens
+        from the KV; those rows get a zero embedding here. The PyTorch path
+        keeps its random-init weight in the same situation. Both behaviors
+        are technically lossy and worth normalizing in a follow-up.
+        """
+        import cupy as cp
+        from .embedders.gensim_word2vec import kv_to_token_aligned_matrix
+
+        kv = self.word2vec_model.wv  # gensim.models.KeyedVectors
+        # Numeric, token-indexed matrix (zeros for any token gensim filtered).
+        vectors = kv_to_token_aligned_matrix(kv, self.word2idx)
+        if len(kv.index_to_key) < vectors.shape[0]:
+            logger.warning(
+                f"gensim KV vocab ({len(kv.index_to_key):,}) is smaller than "
+                f"word2idx ({vectors.shape[0]:,}); "
+                f"{vectors.shape[0] - len(kv.index_to_key):,} tokens were "
+                f"filtered by min_count and will appear as zero embeddings."
+            )
+        cp_arr = cp.asarray(vectors)
+        model_embeddings_df = cudf.DataFrame(
+            {str(i): cp_arr[:, i] for i in range(cp_arr.shape[1])}
+        )
+        model_embeddings_df.columns = model_embeddings_df.columns.astype(str)
+        model_embeddings_df = model_embeddings_df.add_prefix("embedding_")
+        # `self.word2idx` may be dask_cudf; materialize to cudf for the concat,
+        # and sort by token so the row order matches the matrix above.
+        if hasattr(self.word2idx, "compute"):
+            w2i = self.word2idx.compute()
+        else:
+            w2i = self.word2idx
+        w2i = w2i.sort_values("token").reset_index(drop=True)
+        return cudf.concat([w2i, model_embeddings_df], axis=1)
 
     def fit_transform(
         self, edge_df: cudf.DataFrame, walk_vertices: cudf.DataFrame

--- a/test/embedders/gensim_word2vec_test.py
+++ b/test/embedders/gensim_word2vec_test.py
@@ -1,0 +1,278 @@
+"""Tests for the optional gensim Word2Vec backend.
+
+These run on CPU only — gensim is a CPU library, and the streaming
+`WalkCorpus` iterator reads parquet files directly without going through
+cuDF. Tests are skipped at import time if the `gensim` extra isn't
+installed, mirroring the user-facing import gate in
+`embedders.gensim_word2vec`.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Skip the whole module if gensim isn't installed (matches the optional
+# dependency gate). pyarrow is technically optional alongside gensim, but
+# in practice it ships with the cudf install in our environments.
+gensim = pytest.importorskip("gensim")
+pq = pytest.importorskip("pyarrow.parquet")
+import pyarrow as pa  # noqa: E402
+
+from src.rdf2vecgpu.embedders.gensim_word2vec import (  # noqa: E402
+    WalkCorpus,
+    kv_to_token_aligned_matrix,
+    load_id_to_word,
+    train_gensim_word2vec,
+)
+
+
+class _FakeKeyedVectors:
+    """Minimal stand-in for `gensim.models.KeyedVectors` for unit-testing the
+    row-alignment helper without spinning up a real Word2Vec training run.
+
+    Implements just the surface `kv_to_token_aligned_matrix` consumes:
+    `vector_size`, `index_to_key`, and `__getitem__`.
+    """
+
+    def __init__(self, key_to_vector: dict[str, np.ndarray]):
+        if not key_to_vector:
+            raise ValueError("at least one key required")
+        first = next(iter(key_to_vector.values()))
+        self.vector_size = int(first.shape[0])
+        self._kv = {k: v.astype(np.float32) for k, v in key_to_vector.items()}
+        self.index_to_key = list(key_to_vector.keys())
+
+    def __getitem__(self, key):
+        return self._kv[key]
+
+
+@pytest.fixture
+def synthetic_walks(tmp_path: Path) -> Path:
+    """Write a tiny parquet directory shaped like cuGraph's walk output.
+
+    Schema matches `MultiGPUWalkCorpus.random_walk_sequences` /
+    `tools/walk_gen.py`:
+        vertices   : list<int32>   length walk_depth + 1
+        predicates : list<int32>   length walk_depth
+
+    Includes one walk that hits cuGraph's `-1` sentinel partway through to
+    exercise the trim-at-first-sentinel logic.
+    """
+    walks = pa.table(
+        {
+            "vertices": [
+                [0, 1, 2, 3],     # full-length walk
+                [4, 5, 6, 7],     # full-length walk
+                [0, 2, -1, -1],   # walk truncates at index 2
+                [1, 3, 5, 7],     # full-length walk
+            ],
+            "predicates": [
+                [10, 11, 12],
+                [13, 14, 15],
+                [10, -1, -1],
+                [11, 13, 15],
+            ],
+        }
+    )
+    path = tmp_path / "walks"
+    path.mkdir()
+    pq.write_table(walks, path / "part.0.parquet")
+    return path
+
+
+@pytest.fixture
+def synthetic_word2idx() -> pd.DataFrame:
+    """word2idx mapping covering the synthetic walk vocabulary.
+
+    Tokens 0..7 for vertices, 10..15 for predicates. Contiguous tokens are
+    not required for this fixture (gaps are fine for `int_tokens=True`
+    training), but `load_id_to_word` requires contiguous so we test that
+    separately below.
+    """
+    rows = (
+        [(t, f"v{t}") for t in range(8)]
+        + [(t, f"p{t}") for t in range(10, 16)]
+    )
+    return pd.DataFrame(rows, columns=["token", "word"])
+
+
+def test_walk_corpus_streams_interleaved_int_tokens(synthetic_walks):
+    """`int_tokens=True` emits stringified ints; `-1` sentinel trims the walk."""
+    corpus = WalkCorpus(
+        str(synthetic_walks), id_to_word=None, batch_size=2, int_tokens=True
+    )
+    walks = list(iter(corpus))
+    # 4 input walks; the 3rd has end<2 after trim? No — vertices=[0,2,-1,-1]
+    # trims at index 2 → walk_v=[0,2], walk_p=[10] → length 3 (interleaved).
+    assert len(walks) == 4
+    # First walk: [0, 1, 2, 3] vertices + [10, 11, 12] predicates → interleaved
+    # [v0, p10, v1, p11, v2, p12, v3] = ["0", "10", "1", "11", "2", "12", "3"]
+    assert walks[0] == ["0", "10", "1", "11", "2", "12", "3"]
+    # Truncated walk: [0, 2] vertices + [10] predicate → ["0", "10", "2"]
+    assert walks[2] == ["0", "10", "2"]
+
+
+def test_walk_corpus_streams_decoded_uris(synthetic_walks, synthetic_word2idx):
+    """`int_tokens=False` decodes via the id_to_word numpy array."""
+    # Build a dense object array indexed by token. Tokens go up to 15 here,
+    # so size 16. Unset slots stay None (not used by these walks).
+    id_to_word = np.empty(16, dtype=object)
+    for _, row in synthetic_word2idx.iterrows():
+        id_to_word[int(row["token"])] = str(row["word"])
+
+    corpus = WalkCorpus(
+        str(synthetic_walks), id_to_word=id_to_word, batch_size=10
+    )
+    walks = list(iter(corpus))
+    # First walk decoded: vertices [0,1,2,3] → v0,v1,v2,v3; predicates
+    # [10,11,12] → p10,p11,p12; interleaved.
+    assert walks[0] == ["v0", "p10", "v1", "p11", "v2", "p12", "v3"]
+
+
+def test_walk_corpus_drops_walks_below_min_length(tmp_path: Path):
+    """A walk with `-1` at vertex index 1 has fewer than 2 valid vertices and is dropped."""
+    walks = pa.table(
+        {
+            "vertices": [[0, -1, -1, -1], [0, 1, 2, 3]],
+            "predicates": [[-1, -1, -1], [10, 11, 12]],
+        }
+    )
+    walks_dir = tmp_path / "walks"
+    walks_dir.mkdir()
+    pq.write_table(walks, walks_dir / "part.0.parquet")
+    corpus = WalkCorpus(str(walks_dir), id_to_word=None, int_tokens=True)
+    out = list(iter(corpus))
+    # Only the second walk survives.
+    assert len(out) == 1
+    assert out[0] == ["0", "10", "1", "11", "2", "12", "3"]
+
+
+def test_load_id_to_word_requires_contiguous_tokens():
+    """Non-contiguous tokens raise — `_generate_vocab` always produces [0, n)."""
+    bad = pd.DataFrame({"token": [0, 1, 5], "word": ["a", "b", "c"]})
+    with pytest.raises(ValueError, match="not contiguous"):
+        load_id_to_word(bad)
+
+
+def test_load_id_to_word_returns_index_aligned_array():
+    """token-indexed lookup: `arr[t]` returns the word for token t."""
+    df = pd.DataFrame(
+        {"token": [2, 0, 1], "word": ["c", "a", "b"]}  # arbitrary order
+    )
+    arr = load_id_to_word(df)
+    assert len(arr) == 3
+    assert arr[0] == "a" and arr[1] == "b" and arr[2] == "c"
+
+
+def test_train_gensim_word2vec_end_to_end(synthetic_walks, synthetic_word2idx):
+    """Smoke test: gensim trains and KV holds a vector per seen token.
+
+    Note: `synthetic_word2idx` has non-contiguous tokens (gap at 8, 9). This
+    works for the test because `int_tokens=True` skips `load_id_to_word`'s
+    contiguous-token guard — gensim trains directly on stringified int
+    tokens from the walks file, not on URI lookups.
+    """
+    model = train_gensim_word2vec(
+        walks_dir=str(synthetic_walks),
+        word2idx_df=synthetic_word2idx,
+        vector_size=8,
+        window=2,
+        min_count=1,
+        embedding_model="skipgram",
+        negative=2,
+        epochs=2,
+        workers=1,
+        learning_rate=0.025,
+        random_state=42,
+        int_tokens=True,
+    )
+    kv = model.wv
+    # gensim only sees tokens that actually appear in the synthetic walks
+    # (after sentinel trimming): vertices {0,1,2,3,4,5,6,7}, predicates
+    # {10,11,12,13,14,15}. Total 14 unique stringified-int keys.
+    assert kv.vector_size == 8
+    assert "0" in kv  # vertex token
+    assert "10" in kv  # predicate token
+    # Sanity: pulling a vector returns a float32 array of vector_size.
+    v = kv["0"]
+    assert v.shape == (8,) and v.dtype == np.float32
+
+
+def test_kv_to_token_aligned_matrix_int_tokens_alignment():
+    """Stringified-int KV keys map directly to token rows (the default path)."""
+    word2idx = pd.DataFrame(
+        {"token": [0, 1, 2, 3], "word": ["a", "b", "c", "d"]}
+    )
+    # KV trained with int_tokens=True: keys are str(int_token).
+    fake_kv = _FakeKeyedVectors(
+        {
+            "0": np.array([1.0, 0.0, 0.0]),
+            "1": np.array([0.0, 1.0, 0.0]),
+            "2": np.array([0.0, 0.0, 1.0]),
+            "3": np.array([1.0, 1.0, 1.0]),
+        }
+    )
+    matrix = kv_to_token_aligned_matrix(fake_kv, word2idx)
+    assert matrix.shape == (4, 3)
+    assert np.array_equal(matrix[0], [1.0, 0.0, 0.0])
+    assert np.array_equal(matrix[1], [0.0, 1.0, 0.0])
+    assert np.array_equal(matrix[2], [0.0, 0.0, 1.0])
+    assert np.array_equal(matrix[3], [1.0, 1.0, 1.0])
+
+
+def test_kv_to_token_aligned_matrix_min_count_filtered_rows_are_zero():
+    """Tokens dropped by gensim's min_count filter get zero rows.
+
+    This is the documented (lossy) behaviour at min_count > 1: the user's
+    word2idx contains 4 tokens, but gensim only kept 2; the missing two
+    must be zero-filled in the output so the row-index-to-token contract
+    holds.
+    """
+    word2idx = pd.DataFrame(
+        {"token": [0, 1, 2, 3], "word": ["a", "b", "c", "d"]}
+    )
+    fake_kv = _FakeKeyedVectors(
+        {
+            # Tokens 1 and 2 are absent — simulates min_count filtering.
+            "0": np.array([1.0, 2.0]),
+            "3": np.array([3.0, 4.0]),
+        }
+    )
+    matrix = kv_to_token_aligned_matrix(fake_kv, word2idx)
+    assert matrix.shape == (4, 2)
+    assert np.array_equal(matrix[0], [1.0, 2.0])
+    assert np.array_equal(matrix[1], [0.0, 0.0])  # filtered → zero
+    assert np.array_equal(matrix[2], [0.0, 0.0])  # filtered → zero
+    assert np.array_equal(matrix[3], [3.0, 4.0])
+
+
+def test_kv_to_token_aligned_matrix_uri_keys_fallback_lookup():
+    """Non-int KV keys fall back to looking up the token via word2idx['word']."""
+    word2idx = pd.DataFrame(
+        {"token": [0, 1, 2], "word": ["http://a", "http://b", "http://c"]}
+    )
+    # KV trained with int_tokens=False: keys are URIs.
+    fake_kv = _FakeKeyedVectors(
+        {
+            "http://a": np.array([1.0]),
+            "http://c": np.array([3.0]),
+        }
+    )
+    matrix = kv_to_token_aligned_matrix(fake_kv, word2idx)
+    assert matrix.shape == (3, 1)
+    assert matrix[0, 0] == 1.0  # token 0 → http://a → fake_kv["http://a"]
+    assert matrix[1, 0] == 0.0  # not in KV
+    assert matrix[2, 0] == 3.0  # token 2 → http://c
+
+
+def test_kv_to_token_aligned_matrix_dtype_is_float32():
+    """Output matrix is float32, regardless of fake KV's input dtype."""
+    word2idx = pd.DataFrame({"token": [0], "word": ["a"]})
+    fake_kv = _FakeKeyedVectors({"0": np.array([1.0], dtype=np.float64)})
+    matrix = kv_to_token_aligned_matrix(fake_kv, word2idx)
+    assert matrix.dtype == np.float32


### PR DESCRIPTION
 ## Summary

  Adds an optional gensim Word2Vec training backend to `GPU_RDF2Vec`, opt-in
  via `RDF2VecConfig(backend="gensim")` and `pip install rdf2vecgpu[gensim]`.
  Closes the four-PR upstream-port sequence (PR1 walks, PR2 vocab/encode,
  PR3 docs, PR4 gensim backend) and tags **v0.4.0**.

  ### Why

  For Wikidata-scale corpora (~390 M-token vocab, multi-billion walks)
  gensim's C-level negative-sampling Word2Vec is typically 5–10× faster on
  CPU than the equivalent PyTorch skip-gram, and `pyarrow.parquet.ParquetFile.iter_batches`
  keeps memory constant while streaming the full walks corpus. For users on
  CPU-rich + GPU-light boxes (e.g. a single A6000 + a large NUMA box), this
  frees the GPU after walk generation and lets the CPU do the training work.

  ### How

  **Two commits:**

  1. **`feat(gensim): add walks-as-sequences output + gensim trainer module`**
     - New `_walks_to_lists` helper in `corpus/walk_corpus.py` (sister to
       PR1's `_build_walk_steps`) that emits per-walk rows with
       `vertices: list<int>` + `predicates: list<int>` columns — the schema
       gensim's streaming iterator consumes.
     - New `random_walk_sequences()` methods on both `SingleGPUWalkCorpus`
       and `MultiGPUWalkCorpus` that emit this shape (multi-GPU uses the
       same persist+wait + `dd.from_delayed` pattern as PR1's `random_walk`,
       with a partition-layout-drift assertion).
     - New `embedders/gensim_word2vec.py` module with four exports:
       - `WalkCorpus` — streaming parquet iterator, trims cuGraph `-1`
         sentinels, skips walks `<2` valid vertices, materializes batches
         via `pyarrow.parquet.ParquetFile.iter_batches` (constant memory
         even on multi-billion-walk corpora).
       - `load_id_to_word` — scatters `_generate_vocab`'s contiguous-token
         word2idx into a numpy object array indexed by token (avoids the
         ~45 GB Python-dict overhead the standalone tool measured at
         Wikidata scale).
       - `kv_to_token_aligned_matrix` — pure-numpy helper that materializes
         a `gensim.models.KeyedVectors` into a token-indexed matrix (rows
         in `[0, n)` token order, zero-filled for any token gensim's
         `min_count` filter dropped). Extracted as a separate function so
         the row-alignment invariants can be unit-tested without a GPU.
       - `train_gensim_word2vec` — thin wrapper around
         `gensim.models.Word2Vec` forwarding the relevant `RDF2VecConfig`
         fields.
     - New `[project.optional-dependencies].gensim` group in
       `pyproject.toml` (`gensim>=4.3.0`, `pyarrow>=15`). Lazy imports +
       a friendly `_require_gensim()` gate raises pointing at the extra
       if either is missing.

  2. **`feat(gensim): wire dispatch in fit() + transform() + 0.4.0 release`**
     - `GPU_RDF2Vec.fit()` now branches on `self.config.backend`. Default
       (`"pytorch"`) keeps the existing Lightning path verbatim; `"gensim"`
       goes through new `walk_generation_sequences()` and `_fit_via_gensim()`
       (which checkpoints walks to a tempdir parquet via a defensive
       `persist+wait`, tears down the dask cluster if multi-GPU, then
       trains via `train_gensim_word2vec`).
     - `transform()` refactored into a thin dispatcher delegating to
       `_extract_embeddings_pytorch()` (functionally identical to the prior
       body) or new `_extract_embeddings_gensim()` (calls the
       `kv_to_token_aligned_matrix` helper, joins with a token-sorted
       `self.word2idx`, emits a warning if gensim's `min_count` filter
       dropped tokens vs the full word2idx).

  ## Test plan

  - [x] `pytest test/embedders/gensim_word2vec_test.py` — **10/10 pass**
        on CPU (5.9 s) after `pip install rdf2vecgpu[gensim]`:
    - 3 streaming `WalkCorpus` tests (int-token output, URI decode,
      drop-walks-below-min-length)
    - 2 `load_id_to_word` tests (contiguous-token guard, index alignment)
    - 1 `train_gensim_word2vec` end-to-end smoke
    - 4 `kv_to_token_aligned_matrix` row-alignment tests (int-tokens path,
      `min_count`-filtered → zero rows, URI fallback lookup, float32 dtype)
  - [x] **Regression on existing paths verified on GPU (1× RTX 2080 Ti):**
    - `walk_corpus_test.py` — 5/5 pass, ~5 s (PR1 path unchanged)
    - `functions_test.py` — 6/6 pass, ~5 s (PR2 path unchanged)
  - [X] **End-to-end `GPU_RDF2Vec(backend="gensim").fit_transform(...)`
        smoke against a real KG.** Suggested config:
        `RDF2VecConfig(backend="gensim", multi_gpu=False, walk_number=10,
        walk_depth=4, vector_size=64, epochs=1)` on a small parquet KG
        (e.g. `wikidata5m`). The `_fit_via_gensim()` orchestration
        (dask-teardown + parquet checkpoint + gensim train) is unverified
        at this level; the unit + helper tests cover the trainer module
        and the row-alignment logic in isolation but not the full pipeline
        integration.

  ## Notes

  - **No public API breakage** — `RDF2VecConfig.backend` field already
    existed (referenced for tracker tagging in a prior commit); this PR is
    the first to consume it for dispatch. Existing `backend="pytorch"`
    default keeps every existing call site working unchanged.
  - **`walk_strategy="bfs"` + `backend="gensim"` raises `NotImplementedError`**
    for now — bfs+gensim would need a parallel sequences output on
    `bfs_walk`. Random-walk + gensim covers the scaling-motivated use
    case.
  - **Version bump 0.3.0 → 0.4.0**. CHANGELOG `[Unreleased]` graduates to
    `[0.4.0] — 2026-04-27` covering all four PRs in the upstream-port
    sequence (PR1 walks, PR2 vocab/encode, PR3 docs, PR4 gensim backend).
    After merge: tag `v0.4.0`, update the wikidata pipeline's pin to
    `rdf2vecgpu==0.4.0`